### PR TITLE
Revert "Support library compression in production builds"

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,10 +1,6 @@
 Newest changes
 --------------
 
-0.3.37
-
-- Support library compression in production builds
-
 0.3.36
 
 - Add options to query balance and transaction info from waitForTransaction call

--- a/generated/serve/api/openapi.yaml
+++ b/generated/serve/api/openapi.yaml
@@ -12,7 +12,7 @@ info:
     url: https://github.com/mainnet-cash/mainnet-js/blob/master/LICENSE
   termsOfService: https://mainnet.cash/terms/
   title: Mainnet Cash
-  version: 0.3.37
+  version: 0.3.36
 externalDocs:
   description: Find out more about mainnet-js
   url: https://mainnet.cash

--- a/generated/serve/expressServer.js
+++ b/generated/serve/expressServer.js
@@ -37,12 +37,6 @@ class ExpressServer {
     this.app.use(cors());
     const latest = fs.readdirSync(__dirname + '/node_modules/mainnet-js/dist/').filter(val => val.match(/mainnet-\d+\.\d+.\d+.js$/)).pop();
     this.app.use('/scripts/mainnet.js', express.static(__dirname + `/node_modules/mainnet-js/dist/${latest}`));
-    this.app.use('/scripts/mainnet.js.gz', express.static(__dirname + `/node_modules/mainnet-js/dist/${latest}.gz`, {
-      setHeaders: (res, path) => {
-        res.set('Content-Encoding', 'gzip');
-        res.set('Content-Type', 'text/javascript');
-      }
-    }));
     this.app.use(express.static(__dirname + '/static'));
     this.app.use(bodyParser.json({ limit: '15MB' }));
     this.app.use(express.json());

--- a/generated/serve/package.json
+++ b/generated/serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mainnet-cash",
-  "version": "0.3.37",
+  "version": "0.3.36",
   "description": "A developer friendly bitcoin cash wallet api  This API is currently in active development, breaking changes may be made prior to official release of version 1.  **Important:** This library is in active development ",
   "main": "index.js",
   "scripts": {

--- a/generated/serve/static/faucet.html
+++ b/generated/serve/static/faucet.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <script src="https://cdn.jsdelivr.net/npm/vue@2.5.16/dist/vue.js"></script>
-    <script src="/scripts/mainnet.js.gz"></script>
+    <script src="/scripts/mainnet.js"></script>
     <script src="https://unpkg.com/buefy/dist/components/input"></script>
     <script src="https://unpkg.com/buefy/dist/components/button"></script>
     <script src="https://unpkg.com/buefy/dist/components/field"></script>

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "url": "https://github.com/mainnet-cash/mainnet-js/issues"
   },
   "name": "mainnet-js",
-  "version": "0.3.37",
+  "version": "0.3.36",
   "homepage": "https://mainnet.cash",
-  "main": "dist/mainnet-node-0.3.37.js",
-  "browser": "dist/mainnet-0.3.37.js",
+  "main": "dist/mainnet-node-0.3.36.js",
+  "browser": "dist/mainnet-0.3.36.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/*.js",
@@ -53,7 +53,6 @@
     "@types/node": "^15.12.2",
     "@types/pg": "^8.6.0",
     "@types/pg-format": "^1.0.1",
-    "compression-webpack-plugin": "^8.0.1",
     "events": "^3.2.0",
     "fake-indexeddb": "^3.1.2",
     "jest": "^27.0.4",

--- a/swagger/v1/api.yml
+++ b/swagger/v1/api.yml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/mainnet-cash/mainnet-js/blob/master/LICENSE
   termsOfService: https://mainnet.cash/terms/
   title: Mainnet Cash
-  version: 0.3.37
+  version: 0.3.36
 externalDocs:
   description: Find out more about mainnet-js
   url: https://mainnet.cash

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 const { merge } = require("webpack-merge");
 const packageJson = require("./package.json");
 const NpmDtsPlugin = require("npm-dts-webpack-plugin");
-const CompressionWebpackPlugin = require("compression-webpack-plugin");
 
 const baseConfig = {
   entry: "./src/index.ts",
@@ -23,12 +22,6 @@ const baseConfig = {
     mangleWasmImports: true,
     usedExports: true,
   },
-  plugins: [
-    new CompressionWebpackPlugin({
-      algorithm: "gzip",
-      test: /\.(js)$/,
-    }),
-  ],
 };
 
 const prodConfig = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1662,14 +1662,6 @@ component-emitter@^1.3.0:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
-compression-webpack-plugin@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-8.0.1.tgz#13b34403029760e66007f0bac8cf892a2009a3f4"
-  integrity sha512-VWDXcOgEafQDMFXEnoia0VBXJ+RMw81pmqe/EBiOIBnMfY8pG26eqwIS/ytGpzy1rozydltL0zL6KDH9XNWBxQ==
-  dependencies:
-    schema-utils "^3.0.0"
-    serialize-javascript "^6.0.0"
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4677,13 +4669,6 @@ serialize-javascript@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
   integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
-  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
   dependencies:
     randombytes "^2.1.0"
 


### PR DESCRIPTION
Reverts mainnet-cash/mainnet-js#123

Our library is served from a CDN which already provides the best compression supported by the browser. In the best case it is brotli which is compatible or outperforms gzip in compression ratios.