### PR TITLE
bump dexie to 3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "optionalDependencies": {
     "assert": "^2.0.0",
     "deepmerge": "^4.2.2",
-    "dexie": "3.0.3",
+    "dexie": "3.2.2",
     "dotenv": "^10.0.0",
     "ethers": "^5.4.6",
     "eventsource": "^1.0.7",

--- a/packages/mainnet-js/package.json
+++ b/packages/mainnet-js/package.json
@@ -61,7 +61,7 @@
     "@types/pg": "8.6.0",
     "@types/pg-format": "^1.0.1",
     "assert": "^2.0.0",
-    "dexie": "3.0.3",
+    "dexie": "3.2.2",
     "dotenv": "^10.0.0",
     "node-postgres": "^0.6.2",
     "parse-database-url": "^0.3.0",

--- a/packages/mainnet-js/src/network/constant.ts
+++ b/packages/mainnet-js/src/network/constant.ts
@@ -33,8 +33,8 @@ export const mainnetServers = [
 
 // chipnet
 export const testnetServers = [
-  // "wss://chipnet.imaginary.cash:50004",
-  "wss://blackie.c3-soft.com:64004", // chipnet with protocol 1.5.0
+  "wss://chipnet.imaginary.cash:50004",
+  //"wss://blackie.c3-soft.com:64004", // chipnet with protocol 1.5.0
   //"wss://chipnet.bch.ninja:50004"
 ];
 

--- a/packages/mainnet-js/src/network/constant.ts
+++ b/packages/mainnet-js/src/network/constant.ts
@@ -35,6 +35,7 @@ export const mainnetServers = [
 export const testnetServers = [
   // "wss://chipnet.imaginary.cash:50004",
   "wss://blackie.c3-soft.com:64004", // chipnet with protocol 1.5.0
+  //"wss://chipnet.bch.ninja:50004"
 ];
 
 export const regtestServers = ["ws://127.0.0.1:60003"];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2872,10 +2872,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-dexie@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.0.3.tgz#ede63849dfe5f07e13e99bb72a040e8ac1d29dab"
-  integrity sha512-BSFhGpngnCl1DOr+8YNwBDobRMH0ziJs2vts69VilwetHYOtEDcLqo7d/XiIphM0tJZ2rPPyAGd31lgH2Ln3nw==
+dexie@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.2.2.tgz#fa6f2a3c0d6ed0766f8d97a03720056f88fe0e01"
+  integrity sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==
 
 dicer@0.2.5:
   version "0.2.5"


### PR DESCRIPTION
Bumps Dexie to 3.2.2 to Prohibit possible prototype pollution in Dexie.setByKeyPath()

See https://github.com/dexie/Dexie.js/releases/tag/v3.2.2