### PR TITLE
Tweak Address Derivation

### DIFF
--- a/packages/mainnet-js/src/cache/walletCache.ts
+++ b/packages/mainnet-js/src/cache/walletCache.ts
@@ -164,9 +164,13 @@ export class PersistentWalletCache implements WalletCacheI {
   public getByIndex(addressIndex: number, change: boolean) {
     const id = `${this.walletId}-${addressIndex}-${change}`;
     if (!this.walletCache[id]) {
+      let relativePath = `${change ? 1 : 0}/${addressIndex}`
+      if (this.hdNode.depth === 4) {
+        relativePath = `${addressIndex}`
+      }
       const node = deriveHdPathRelative(
         this.hdNode,
-        `${change ? 1 : 0}/${addressIndex}`
+        relativePath
       );
 
       const privateKey = "privateKey" in node ? node.privateKey : undefined;


### PR DESCRIPTION
- Fixes incorrect address derivation when HDWallet is derived from an Xpub at BIP-44 change level (depth 4)
- This'll allow support of instantiating HDWallet from change level XPubs which are used in Wizard Connect
